### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   # Kafka
   kafka:
-    image: bitnami/kafka:3.4
+    image: soldevelo/kafka:3.4
     restart: unless-stopped
     environment:
       - KAFKA_CFG_NODE_ID=0

--- a/manifests/kafka.yaml
+++ b/manifests/kafka.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: bitnami/kafka:3.4
+        image: soldevelo/kafka:3.4
         ports:
         - containerPort: 19093
         - containerPort: 19092


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/kafka:3.4` → [`soldevelo/kafka:3.4`](https://hub.docker.com/r/soldevelo/kafka)